### PR TITLE
Allow specifying image URL to display

### DIFF
--- a/server/yailsrv.py
+++ b/server/yailsrv.py
@@ -314,6 +314,11 @@ def handle_client_connection(client_socket):
                     url = urls[url_idx]
                     time.sleep(1)
 
+            elif tokens[0] == 'showurl':
+                while not stream_YAI(tokens[1], client_socket, gfx_mode):
+                    print('Problem with image.')
+                    time.sleep(1)
+
             elif tokens[0] == 'next':
                 url_idx = random.randint(0, len(urls)-1)
                 url = urls[url_idx]

--- a/src/console.c
+++ b/src/console.c
@@ -243,6 +243,29 @@ void process_command(byte ntokens)
             stream_image(&tokens[1]);
         }
     }
+
+    if(strncmp(tokens[0], "showurl", 3) == 0)
+    {
+        if(ntokens < 2)
+        {
+            gotoxy(0,0);
+            cputs("ERROR: URL not specified");
+            cgetc();
+        }
+        else
+        {
+            #ifdef DEBUG_CONSOLE
+            byte i;
+            for(i = 0; tokens[i] != 0x0; i++)
+                cprintf("*%s ", tokens[i]);
+
+            cputs("\n\r");
+            #endif
+
+            show_image(&tokens[1]);
+        }
+    }
+
 }
 
 void start_console(char first_char)

--- a/src/netimage.c
+++ b/src/netimage.c
@@ -164,3 +164,150 @@ void stream_image(char* args[])
 
     OS.soundr = 3; // Restore SIO beeping sound
 }
+
+void show_image(char* args[])
+{
+    const ushort bytes_per_line = 40;
+    const ushort lines = 220;
+    ushort buffer_start;
+    ushort block_size;
+    ushort lines_per_block;
+    ushort dl_block_size;
+    ushort ttl_buff_size;
+    ushort read_size;
+    ushort i;
+
+    OS.soundr = 0; // Turn off SIO beeping sound
+
+    #if DEBUG
+    cprintf("reading from %s\n\r", url);
+    for(i = 0; args[i] != 0x0; i++)
+        cprintf("%s ", args[i]);
+    cputs("\n\r");
+    #endif
+
+    hide_console();
+
+    if(FN_ERR_OK != network_init())
+    {
+        show_console();
+        cputs("Failed to initialize network\n\r");
+        network_close(settings.url);
+        return;
+    }
+
+    if(FN_ERR_OK != network_open(settings.url, 12, 0))
+    {
+        show_console();
+        cprintf("Failed to open %s\n\r", settings.url);
+        network_close(settings.url);
+        return;
+    }
+
+    // Send which graphics mode we are in
+    memset(buff, 0, 256);
+    sprintf(buff, "gfx %d ", settings.gfx_mode &= ~GRAPHICS_CONSOLE_EN);
+    if(FN_ERR_OK != network_write(settings.url, buff, 6))
+    {
+        show_console();
+        cprintf("Unable to write graphics mode \"%s\"\n\r", buff);
+        network_close(settings.url);
+        return;
+    }
+
+    // Build up the search string
+    memset(buff, 0, 256);
+    memcpy(buff, "showurl \"", 8);
+    for(i = 0; i < 8; ++i)
+    {
+        if(0x0 == args[i])
+            break;
+
+        if(i > 0)
+            strcat(buff, " ");
+        strcat(buff, args[i]);
+    }
+    strcat(buff, "\"");
+
+    i = strlen(buff);
+
+    if(FN_ERR_OK != network_write(settings.url, buff, i))
+    {
+        show_console();
+        cprintf("Unable to write request\n\r");
+        network_close(settings.url);
+        return;
+    }
+
+    while(true)
+    {
+        if(kbhit())
+        {
+            cgetc();
+            break;
+        }
+        else
+        {
+            buffer_start = image.data;
+            block_size = DISPLAYLIST_BLOCK_SIZE;
+            lines_per_block = (ushort)(block_size/bytes_per_line);
+            dl_block_size = lines_per_block * bytes_per_line;
+            ttl_buff_size = lines * bytes_per_line;
+            read_size = dl_block_size;
+
+            // Read the header
+            if(FN_ERR_OK != network_read(settings.url, (unsigned char*)&image.header, sizeof(image.header)))
+            {
+                show_console();
+                cprintf("Error reading\n\r");
+                network_close(settings.url);
+                break;
+            }
+
+            setGraphicsMode(image.header.gfx);
+
+            while(ttl_buff_size > 0)
+            {
+                if(read_size > ttl_buff_size)
+                    read_size = ttl_buff_size;
+
+                clrscr();
+                if(FN_ERR_OK != network_read(settings.url, buffer_start, read_size))
+                {
+                    show_console();
+                    cprintf("Error reading\n\r");
+                    network_close(settings.url);
+                    break;
+                }
+
+                buffer_start = buffer_start + block_size;
+                ttl_buff_size = ttl_buff_size - read_size;
+            }
+
+            // Wait for keypress
+            i = 0;
+            while(i++ < 30000)   // roughly 5 seconds
+                if(kbhit())
+                    break;
+
+            if(FN_ERR_OK != network_write(settings.url, "next", 4))
+            {
+                show_console();
+                cprintf("Unable to write request\n\r");
+                break;
+            }
+        }
+
+        OS.atract = 0x00;   // disable attract mode
+    }
+
+    if(FN_ERR_OK != network_write(settings.url, "quit", 4))
+    {
+        show_console();
+        cprintf("Unable to write request\n\r");
+    }
+
+    network_close(settings.url);
+
+    OS.soundr = 3; // Restore SIO beeping sound
+}

--- a/src/netimage.h
+++ b/src/netimage.h
@@ -17,5 +17,6 @@ signed char check_network(const char* url);
 signed char write_network(const char* url, const char* buf, unsigned short len);
 signed char read_network(const char* url, unsigned char* buf, unsigned short len);
 void stream_image(char* args[]);
+void show_image(char* args[]);
 
 #endif // NETIMAGE_H


### PR DESCRIPTION
The client can use command `showurl` with a URL as the parameter which is sent to server that responds with the image at given the URL.