### PR TITLE
v1.2.17: Server exits with ctrl-c

### DIFF
--- a/server/yailsrv.py
+++ b/server/yailsrv.py
@@ -361,9 +361,8 @@ def handle_client_connection(client_socket):
 
 import signal
 def handler(signum, frame):
-    res = input("Ctrl-c was pressed. Do you really want to exit? y/n ")
-    if res == 'y':
-        sys.exit(1)
+    print('SIGINT: Exiting...')
+    sys.exit(1)
  
 signal.signal(signal.SIGINT, handler)
 

--- a/server/yailsrv.py
+++ b/server/yailsrv.py
@@ -16,6 +16,7 @@ from fastcore.all import *
 from pprint import pprint
 from PIL import Image
 import numpy as np
+import sys
 #import asyncio
 
 GRAPHICS_8 = 2
@@ -358,8 +359,16 @@ def handle_client_connection(client_socket):
         client_socket.close()
         #loop.close()  # Close the loop when done
 
+import signal
+def handler(signum, frame):
+    res = input("Ctrl-c was pressed. Do you really want to exit? y/n ")
+    if res == 'y':
+        sys.exit(1)
+ 
+signal.signal(signal.SIGINT, handler)
+
 def main():
-    connections = 0
+    threads = []
     while True:
         client_sock, address = server.accept()
         print('Accepted connection from {}:{}'.format(address[0], address[1]))
@@ -367,9 +376,16 @@ def main():
             target=handle_client_connection,
             args=(client_sock,)  # without comma you'd get a... TypeError: handle_client_connection() argument after * must be a sequence, not _socketobject
         )
-        connections += 1
+        client_handler.daemon = True
         client_handler.start()
-        print('Connections:', connections)
+        threads.append(client_handler)
+        print('Connections:', len(threads))
+    '''
+    try:
+    except KeyboardInterrupt:
+        print("Ctrl+C pressed...")
+        sys.exit(1)
+    '''
 
 if __name__ == "__main__":
     main()

--- a/src/version.h
+++ b/src/version.h
@@ -5,6 +5,6 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION 2
-#define BUILD_VERSION 16
+#define BUILD_VERSION 17
 
 #endif // YAIL_VERSION_H


### PR DESCRIPTION
YAILSRV doesnt have a good exit strategy.  This is a heavy handed approach that installs a signal handler for SIGINT (ctrl-C) and exits the application, in whatever state it's in, when it receives the signal.

Need to re-work things so that both the asyncio of the DDG handler is properly told to die as well as the rest of the app.