### PR TITLE
v1.3.4: Disables BASIC on systems where this can be an issue.

### DIFF
--- a/src/preinit.s
+++ b/src/preinit.s
@@ -1,0 +1,38 @@
+        .export     pre_init
+        .include    "atari.inc"
+;        .include    "macros.inc"
+
+; https://github.com/markjfisher/fujinet-config-ng/blob/master/src/atari/common/init/pre_init.s
+
+; this segment is loaded during disk load before dlist and main are loaded
+; the memory location will be written over by later blocks, which is fine, it's only needed for one time initial setup
+.segment "INIT"
+.proc pre_init
+        lda     #$c0        ; check if ramtop is already ok
+        cmp     RAMTOP
+        beq     ramok
+        sta     RAMTOP      ; set ramtop to end of basic
+        sta     RAMSIZ      ; and ramsiz too
+
+        lda     PORTB
+        ora     #$02        ; disable basic bit
+        sta     PORTB
+
+        lda     #$01        ; keep it off after reset
+        sta     BASICF
+
+        ldx     #$02        ; CLOSE "E"
+        jsr     editor
+        ldx     #$00        ; OPEN "E"
+editor:
+        ; dispatch based JMP!
+        lda     EDITRV+1, x
+        pha
+        lda     EDITRV, x
+        pha
+        ; now ready to JMP on a RTS
+ramok:
+        rts
+
+clear_from:
+.endproc

--- a/src/version.h
+++ b/src/version.h
@@ -5,6 +5,6 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION 3
-#define BUILD_VERSION 3
+#define BUILD_VERSION 4
 
 #endif // YAIL_VERSION_H

--- a/src/yail.atari-xex.cfg
+++ b/src/yail.atari-xex.cfg
@@ -13,6 +13,11 @@ SYMBOLS {
 }
 MEMORY {
     ZP:         file = "", define = yes, start = $0082, size = $007E;
+
+# Preinitialization  1 - Disable BASIC
+    PRE:        file = %O, define = no,  start = $2000, size = $0200; # init code that runs once and then overwritten (by SCREEN data etc)
+    PRE_NOSAV:  file = "", define = no,  start = $2200, size = $0100; # work aread for PRE-INIT routines that will be overwritten and not saved to disk
+
 # "system check" load chunk
     #SYSCHKCHNK: file = %O,               start = $2E00, size = $0300;
 # "main program" load chunk
@@ -22,12 +27,15 @@ FILES {
     %O: format = atari;
 }
 FORMATS {
-    atari: runad = start; #,
+    atari: runad = start,
+           initad = PRE: pre_init; #,
            #initad = SYSCHKCHNK: __SYSTEM_CHECK__;
 }
 SEGMENTS {
     ZEROPAGE:  load = ZP,         type = zp;
     EXTZP:     load = ZP,         type = zp,                optional = yes;
+    INIT:     load = PRE,        type = ro,  define = yes;  # initialisation routines that will be overwritten
+    INIT_NS:  load = PRE_NOSAV,  type = rw,  define = yes;  # used as temporary bss-like data area for init routines but will be reused
     #SYSCHK:    load = SYSCHKCHNK, type = rw,  define = yes, optional = yes;
     STARTUP:   load = MAIN,       type = ro,  define = yes;
     LOWBSS:    load = MAIN,       type = rw,                optional = yes;  # not zero initialized
@@ -36,9 +44,9 @@ SEGMENTS {
     CODE:      load = MAIN,       type = ro,  define = yes;
     RODATA:    load = MAIN,       type = ro;
     DATA:      load = MAIN,       type = rw;
-    INIT:      load = MAIN,       type = rw,                optional = yes;
+    #INIT:      load = MAIN,       type = rw,                optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
-	
+
     GFX8_DL:         load = MAIN, type = rw,  align = $0400,  define = yes;
     #GFX8_CONSOLE_DL: load = MAIN, type = rw,  align = $0100,  define = yes;
     #GFX9_CONSOLE_DL: load = MAIN, type = rw,  align = $0100,  define = yes;


### PR DESCRIPTION
YAIL, currently, is a memory pig.  This helps keep it that way.  Screw basic!