### PR TITLE
Server fixes global gfxmode

### DIFF
--- a/Makefile.mak
+++ b/Makefile.mak
@@ -7,6 +7,7 @@ PRODUCT=YAIL
 TARGET=atari
 SRC_DIR=src
 #CFLAGS=-Osri
+#CFLAGS=-Os -DYAIL_BUILD_FILE_LOADER
 CFLAGS=-Os
 LINKFLAGS=-D__SYSTEM_CHECK__=1
 #LINKFLAGS=--debug-info -Wl --dbgfile,"myapp.dbg"

--- a/server/yeet_to_yail.py
+++ b/server/yeet_to_yail.py
@@ -35,8 +35,6 @@ YAIL_H = 220
 # it won't be written by the server.
 mutex = Lock()
 yail_data = None
-
-#gfx_mode = GRAPHICS_8
 connections = 0
 camera_thread = None
 camera_done = False
@@ -110,8 +108,6 @@ def show_shades(image_data: np.ndarray) -> None:
 
 def convertToYai(image_data: bytearray, gfx_mode: int) -> bytearray:
     import struct
-
-    #global gfx_mode
 
     ttlbytes = image_data.shape[0] * image_data.shape[1]
 
@@ -290,10 +286,9 @@ def camera_handler(gfx_mode: int) -> None:
 def handle_client_connection(client_socket: socket.socket) -> None:
     # Set up a new event loop for this thread
     global connections
-    #global gfx_mode
-    gfx_mode = GRAPHICS_8
     global camera_thread
     global camera_done
+    gfx_mode = GRAPHICS_8
     client_mode = None
 
     connections = connections + 1

--- a/server/yeet_to_yail.py
+++ b/server/yeet_to_yail.py
@@ -36,14 +36,14 @@ YAIL_H = 220
 mutex = Lock()
 yail_data = None
 
-gfx_mode = GRAPHICS_8
+#gfx_mode = GRAPHICS_8
 connections = 0
 camera_thread = None
 camera_done = False
 filenames = []
 camera_name = None
 
-def fix_aspect(image, crop=False):
+def fix_aspect(image: Image.Image, crop: bool=False) -> Image.Image:
     aspect = YAIL_W/YAIL_H   # YAIL aspect ratio
     aspect_i = 1/aspect
     w = image.size[0]
@@ -75,14 +75,14 @@ def fix_aspect(image, crop=False):
 
     return image
 
-def dither_image(image):
+def dither_image(image: Image.Image) -> Image.Image:
     return image.convert('1')
 
-def pack_bits(image):
+def pack_bits(image: Image.Image) -> np.ndarray:
     bits = np.array(image)
     return np.packbits(bits, axis=1)
 
-def pack_shades(image):
+def pack_shades(image: Image.Image) -> np.ndarray:
     yail = image.resize((int(YAIL_W/4),YAIL_H), Image.LANCZOS)
     yail = yail.convert(dither=Image.FLOYDSTEINBERG, colors=16)
 
@@ -101,17 +101,17 @@ def pack_shades(image):
     
     return combined.astype('int8')
 
-def show_dithered(image):
+def show_dithered(image: Image.Image) -> None:
     image.show()
 
-def show_shades(image_data):
+def show_shades(image_data: np.ndarray) -> None:
     pil_image_yai = Image.fromarray(image_data, mode='L')
     pil_image_yai.resize((320,220), resample=None).show()
 
-def convertToYai(image_data):
+def convertToYai(image_data: bytearray, gfx_mode: int) -> bytearray:
     import struct
 
-    global gfx_mode
+    #global gfx_mode
 
     ttlbytes = image_data.shape[0] * image_data.shape[1]
 
@@ -124,17 +124,17 @@ def convertToYai(image_data):
 
     return image_yai
 
-def update_yail_data(data, thread_safe=True):
+def update_yail_data(data: np.ndarray, gfx_mode: int, thread_safe: bool = True) -> None:
     global yail_data
     if thread_safe:
         mutex.acquire()
     try:
-        yail_data = convertToYai(data)
+        yail_data = convertToYai(data, gfx_mode)
     finally:
         if thread_safe:
             mutex.release()
 
-def send_yail_data(client_socket, thread_safe=True):
+def send_yail_data(client_socket: socket.socket, thread_safe: bool=True) -> None:
     global yail_data
 
     if thread_safe:
@@ -149,7 +149,7 @@ def send_yail_data(client_socket, thread_safe=True):
         client_socket.sendall(data)
         logger.info('Sent YAIL data')
 
-def stream_YAI(client: str, gfx_mode: int, url: str = None, filepath: str = None):  #url, client, gfx_mode):
+def stream_YAI(client: str, gfx_mode: int, url: str = None, filepath: str = None) -> bool:
     from io import BytesIO
 
     # download the body of response by chunk, not immediately
@@ -198,7 +198,7 @@ def stream_YAI(client: str, gfx_mode: int, url: str = None, filepath: str = None
         elif gfx_mode == GRAPHICS_9:
             image_data = pack_shades(gray)
 
-        image_yai = convertToYai(image_data)
+        image_yai = convertToYai(image_data, gfx_mode)
 
         client.sendall(image_yai)
 
@@ -209,7 +209,7 @@ def stream_YAI(client: str, gfx_mode: int, url: str = None, filepath: str = None
         return False
 
 # This uses the DuckDuckGo search engine to find images.  This is handled by the duckduckgo_search package.
-def search_images(term, max_images=1000):
+def search_images(term: str, max_images: int=1000) -> list:
     logger.info(f"Searching for '{term}'")
     with DDGS() as ddgs:
         results = L([r for r in ddgs.images(term, max_results=max_images)])
@@ -220,7 +220,7 @@ def search_images(term, max_images=1000):
 
         return urls
 
-def camera_handler():
+def camera_handler(gfx_mode: int) -> None:
     import pygame.camera
     import pygame.image
 
@@ -287,10 +287,11 @@ def camera_handler():
 
     camera_done = False
 
-def handle_client_connection(client_socket):
+def handle_client_connection(client_socket: socket.socket) -> None:
     # Set up a new event loop for this thread
     global connections
-    global gfx_mode
+    #global gfx_mode
+    gfx_mode = GRAPHICS_8
     global camera_thread
     global camera_done
     client_mode = None
@@ -433,7 +434,7 @@ def main():
 
     # Initialize the image to send with something
     initial_image = Image.new("L", (YAIL_W,YAIL_H))
-    update_yail_data(pack_shades(initial_image))
+    update_yail_data(pack_shades(initial_image), GRAPHICS_8)
 
     bind_ip = '0.0.0.0'
     bind_port = 5556

--- a/src/console.c
+++ b/src/console.c
@@ -183,16 +183,20 @@ char process_command(byte ntokens)
         }
         else
         {
+            /*
             gotoxy(0,0);
             clrscr();
             cputs("ERROR: File not specified");
-            cgetc();
+            */
+            show_error_pause("ERROR: File not specified");
         }
         #else
+            /*
             gotoxy(0,0);
             clrscr();
             cputs("ERROR: File loading not supported");
-            cgetc();
+            */
+            show_error_pause("ERROR: File not specified");
         #endif
     }
 
@@ -204,15 +208,10 @@ char process_command(byte ntokens)
 
         else
         {
-            gotoxy(0,0);
-            cprintf("ERROR: File not specified");
-            cgetc();
+            show_error_pause("ERROR: File not specified");
         }
         #else
-            gotoxy(0,0);
-            clrscr();
-            cputs("ERROR: File saving not supported");
-            cgetc();
+            show_error_pause("ERROR: File saving not supported");
         #endif
     }
 
@@ -220,9 +219,7 @@ char process_command(byte ntokens)
     {
         if(ntokens < 3)
         {
-            gotoxy(0,0);
-            cputs("ERROR: Must specify a setting and value");
-            cgetc();
+            show_error_pause("ERROR: Must specify a setting and value");
         }
         else
         {
@@ -259,9 +256,7 @@ char process_command(byte ntokens)
     {
         if(ntokens < 2)
         {
-            gotoxy(0,0);
-            cputs("ERROR: URL not specified");
-            cgetc();
+            show_error_pause("ERROR: URL not specified");
         }
         else
         {

--- a/src/files.c
+++ b/src/files.c
@@ -63,6 +63,7 @@ byte imageFileType(const char filename[])
 
 void saveFile(const char filename[])
 {
+    size_t size;
     int fd = open(filename, O_WRONLY);
 
     if(fd >= 0)
@@ -91,6 +92,7 @@ void saveFile(const char filename[])
         #define IMAGE_BLOCK_ONE_TWO_SIZE 4080
         #define IMAGE_BLOCK_THREE_SIZE 640
         b = MEM_TOKEN;
+        size = IMAGE_BLOCK_ONE_TWO_SIZE;
         write(fd, &b, 1);
         write(fd, &size, sizeof(size_t));
         write(fd, image.data, IMAGE_BLOCK_ONE_TWO_SIZE);
@@ -99,6 +101,7 @@ void saveFile(const char filename[])
         write(fd, &size, sizeof(size_t));
         write(fd, (image.data+0x1000), IMAGE_BLOCK_ONE_TWO_SIZE);
 
+        size = IMAGE_BLOCK_THREE_SIZE;
         write(fd, &b, 1);
         write(fd, &size, sizeof(size_t));
         write(fd, (image.data+0x2000), IMAGE_BLOCK_THREE_SIZE);

--- a/src/utility.c
+++ b/src/utility.c
@@ -59,3 +59,9 @@ void show_error(const char* message)
     show_console();
     cputs(message);
 }
+
+void show_error_pause(const char* message)
+{
+    show_error(message);
+    cgetc();
+}

--- a/src/utility.h
+++ b/src/utility.h
@@ -12,6 +12,7 @@ void pause(const char* message);
 void internal_to_atascii(char* buff, byte len);
 void atascii_to_internal(char* buff, byte len);
 void show_error(const char* message);
+void show_error_pause(const char* message);
 extern void add_attract_disable_vbi();
 extern void remove_attract_disable_vbi();
 void wait_vbi(void);

--- a/src/version.h
+++ b/src/version.h
@@ -5,6 +5,6 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION 3
-#define BUILD_VERSION 4
+#define BUILD_VERSION 5
 
 #endif // YAIL_VERSION_H

--- a/src/yail.atari-xex.cfg
+++ b/src/yail.atari-xex.cfg
@@ -16,7 +16,7 @@ MEMORY {
 
 # Preinitialization  1 - Disable BASIC
     PRE:        file = %O, define = no,  start = $2000, size = $0200; # init code that runs once and then overwritten (by SCREEN data etc)
-    PRE_NOSAV:  file = "", define = no,  start = $2200, size = $0100; # work aread for PRE-INIT routines that will be overwritten and not saved to disk
+    #PRE_NOSAV:  file = "", define = no,  start = $2200, size = $0100; # work aread for PRE-INIT routines that will be overwritten and not saved to disk
 
 # "system check" load chunk
     #SYSCHKCHNK: file = %O,               start = $2E00, size = $0300;
@@ -35,7 +35,7 @@ SEGMENTS {
     ZEROPAGE:  load = ZP,         type = zp;
     EXTZP:     load = ZP,         type = zp,                optional = yes;
     INIT:     load = PRE,        type = ro,  define = yes;  # initialisation routines that will be overwritten
-    INIT_NS:  load = PRE_NOSAV,  type = rw,  define = yes;  # used as temporary bss-like data area for init routines but will be reused
+    #INIT_NS:  load = PRE_NOSAV,  type = rw,  define = yes;  # used as temporary bss-like data area for init routines but will be reused
     #SYSCHK:    load = SYSCHKCHNK, type = rw,  define = yes, optional = yes;
     STARTUP:   load = MAIN,       type = ro,  define = yes;
     LOWBSS:    load = MAIN,       type = rw,                optional = yes;  # not zero initialized
@@ -47,10 +47,10 @@ SEGMENTS {
     #INIT:      load = MAIN,       type = rw,                optional = yes;
     BSS:       load = MAIN,       type = bss, define = yes;
 
-    GFX8_DL:         load = MAIN, type = rw,  align = $0400,  define = yes;
     #GFX8_CONSOLE_DL: load = MAIN, type = rw,  align = $0100,  define = yes;
     #GFX9_CONSOLE_DL: load = MAIN, type = rw,  align = $0100,  define = yes;
     FRAMEBUFFER:     load = MAIN, type = rw,  align = $1000,  define = yes;
+    GFX8_DL:         load = MAIN, type = rw,  align = $0400,  define = yes;
 }
 FEATURES {
     CONDES: type    = constructor,


### PR DESCRIPTION
The yail server (yeet_to_yail) had declared it's current graphics mode state globally. Not sure why I did this, mabye expediancy. This does/did not work with the threading model for handling the network connection.
This update fixes that.